### PR TITLE
Fix BaseLayout invocation syntax

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import ReadMore from "../components/ReadMore.astro";
 import Card from "../components/Card.astro";
 ---
 
-<BaseLayout title="Epeat\'s Site" , selected={Astro.self.name} ,>
+<BaseLayout title="Epeat\'s Site" selected={Astro.self.name}>
   <Card class="flex max-w-xs md:max-w-2xl md:min-w-sm shadow-lg shadow-blade-400/20">
     <div class="flex flex-col gap-2">
       <section class="flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- fix stray commas in index page BaseLayout tag causing build errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f3be259948321ab025d79323633ab