### PR TITLE
docs: document landing page

### DIFF
--- a/README.astro.md
+++ b/README.astro.md
@@ -1,47 +1,25 @@
-# Astro Starter Kit: Minimal
+# Landing Page
 
-```sh
-npm create astro@latest -- --template minimal
+This repository contains the source for a personal landing page built with [Astro](https://astro.build) and Tailwind CSS. It ships with the [Dracula](https://draculatheme.com/) color palette via the `tailwind-dracula` plugin, giving the site its distinctive dark theme. Use it as a starting point to introduce yourself or showcase a project.
+
+## Project Structure
+
 ```
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
 /
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
+├── public/              # Static assets such as fonts and favicon
+└── src/
+    ├── components/     # Reusable Astro components
+    ├── layouts/        # Page layouts
+    └── pages/          # Route files (e.g. index.astro)
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## Usage
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+- `npm install` – install dependencies
+- `npm run dev` – start a development server at `http://localhost:4321`
+- `npm run build` – build the production site into `dist/`
+- `npm run preview` – preview the build locally
+- The dark theme comes from the `tailwind-dracula` plugin defined in `tailwind.config.js`; adjust or remove it to use a different palette.
 
-Any static assets, like images, can be placed in the `public/` directory.
+Customize the content by editing files in `src/pages` and `src/components`.
 
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).


### PR DESCRIPTION
## Summary
- replace Astro starter text with landing page documentation
- describe project structure and common scripts
- note use of Dracula palette via tailwind-dracula plugin

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f3fcbcf40832184b511c42cf55da6